### PR TITLE
Disable fast_math, fmad, and ftz

### DIFF
--- a/candle-flash-attn/build.rs
+++ b/candle-flash-attn/build.rs
@@ -98,8 +98,8 @@ fn main() -> Result<()> {
         .arg("-O3")
         .arg("-fmad=false")       // Disable FMA rounding non-determinism
         .arg("-ftz=false")        // Preserve subnormals (critical for attention)
-//        .arg("-prec-div")         // Enable precise division
-//        .arg("-prec-sqrt")        // Enable precise square-root
+        .arg("-prec-div=true")         // Enable precise division
+        .arg("-prec-sqrt=true")        // Enable precise square-root
         .arg("-std=c++17")
         .arg("-U__CUDA_NO_HALF_OPERATORS__")
         .arg("-U__CUDA_NO_HALF_CONVERSIONS__")

--- a/candle-flash-attn/build.rs
+++ b/candle-flash-attn/build.rs
@@ -96,6 +96,10 @@ fn main() -> Result<()> {
         .out_dir(&build_dir)
         .with_cutlass(None) // ✅ Auto-fetch CUTLASS from GitHub
         .arg("-O3")
+        .arg("-fmad=false")       // Disable FMA rounding non-determinism
+        .arg("-ftz=false")        // Preserve subnormals (critical for attention)
+//        .arg("-prec-div")         // Enable precise division
+//        .arg("-prec-sqrt")        // Enable precise square-root
         .arg("-std=c++17")
         .arg("-U__CUDA_NO_HALF_OPERATORS__")
         .arg("-U__CUDA_NO_HALF_CONVERSIONS__")

--- a/candle-kernels/build.rs
+++ b/candle-kernels/build.rs
@@ -6,12 +6,15 @@ fn main() {
     println!("cargo:rerun-if-changed=src/cuda_utils.cuh");
     println!("cargo:rerun-if-changed=src/binary_op_macros.cuh");
 
-    let bindings = KernelBuilder::new()
+    let mut bindings = KernelBuilder::new()
         .source_dir("src") // Scan src/ for .cu files
+        .arg("-fmad=false")       // Disable FMA rounding non-determinism
+        .arg("-ftz=false")        // Preserve subnormals (critical for attention)
         .build_ptx()
-        .expect("Failed to compile CUDA kernels");
-
-    bindings
+        .expect("Failed to compile CUDA kernels")
         .write("src/lib.rs")
         .expect("Failed to write PTX bindings");
+//        .arg("-prec-div")         // Enable precise division
+//        .arg("-prec-sqrt")        // Enable precise square-root
+
 }

--- a/candle-kernels/build.rs
+++ b/candle-kernels/build.rs
@@ -10,11 +10,10 @@ fn main() {
         .source_dir("src") // Scan src/ for .cu files
         .arg("-fmad=false")       // Disable FMA rounding non-determinism
         .arg("-ftz=false")        // Preserve subnormals (critical for attention)
+        .arg("-prec-div=true")         // Enable precise division
+        .arg("-prec-sqrt=true")        // Enable precise square-root
         .build_ptx()
         .expect("Failed to compile CUDA kernels")
         .write("src/lib.rs")
         .expect("Failed to write PTX bindings");
-//        .arg("-prec-div")         // Enable precise division
-//        .arg("-prec-sqrt")        // Enable precise square-root
-
 }


### PR DESCRIPTION
Adjust nvcc flags to enhance accuracy across the range of supported architectures:

1. Drop use_fast_math from FA kernels
2. Disable non-deterministic rounding in FP maths (fmad=false)
3. Preserve subnormals (ftz=false)

Precise division and square root options left commented-out for now but annotated in case they are found useful down the line.